### PR TITLE
Feat: Standardize Responses and Errors

### DIFF
--- a/src/api/controllers/auth.js
+++ b/src/api/controllers/auth.js
@@ -1,10 +1,14 @@
+const {
+  SuccessResponse,
+  EmptySuccessResponse,
+} = require('../../core/api-response')
+const { BadRequestError } = require('../../core/api-error')
 const { AuthRepo } = require('../../database/repositories')
 
 const getUser = async (req, res, next) => {
   const u = { id: 'xmeax' }
   const user = await AuthRepo.readUser(u.id)
-  res.status(200).json({ user })
-  return next()
+  new SuccessResponse({ user }).send(res)
 }
 
 const patchUser = async (req, res, next) => {
@@ -21,13 +25,7 @@ const patchUser = async (req, res, next) => {
   //    - https://express-validator.github.io/docs/
   //    - https://github.com/validatorjs/validator.js
   if (!data || (!data.email && !data.frequency && !data.refresh_token)) {
-    const error = {
-      status: 400,
-      message:
-        'Missing or malformed request body. Fields qualified for updating: `email`, `frequency`, `refresh_token`',
-    }
-    res.status(error.status).json({ error })
-    return next()
+    throw new BadRequestError('Missing or malformed request body')
   }
 
   // remove all other attributes other than the updatable attributes
@@ -41,15 +39,13 @@ const patchUser = async (req, res, next) => {
   }
 
   await AuthRepo.updateUser(u.id, data)
-  res.status(204).end()
-  return next()
+  new EmptySuccessResponse().send(res)
 }
 
 const deleteUser = async (req, res, next) => {
   const u = { id: 'xmeax' }
   await AuthRepo.removeUser(u.id)
-  res.status(204).end()
-  return next()
+  new EmptySuccessResponse().send(res)
 }
 
 const oauthDance = async (req, res, next) => {

--- a/src/api/controllers/tags.js
+++ b/src/api/controllers/tags.js
@@ -1,3 +1,9 @@
+const {
+  SuccessResponse,
+  EmptySuccessResponse,
+  CreatedSuccessResponse,
+} = require('../../core/api-response')
+const { BadRequestError, NotFoundError } = require('../../core/api-error')
 const { TagsRepo } = require('../../database/repositories')
 
 const getTag = async (req, res, next) => {
@@ -9,16 +15,9 @@ const getTag = async (req, res, next) => {
 
   const tag = await TagsRepo.readTagById(user.id, id)
   if (!tag) {
-    const error = {
-      status: 404,
-      message:
-        'Could not find any tag with the given id associated with the authorized user.',
-    }
-    res.status(error.status).json({ error })
-    return next()
+    throw new NotFoundError('No tag found with the given id')
   }
-  res.status(200).json({ tag })
-  return next()
+  new SuccessResponse({ tag }).send(res)
 }
 
 const getTags = async (req, res, next) => {
@@ -27,8 +26,7 @@ const getTags = async (req, res, next) => {
   req.user = user
 
   const tags = await TagsRepo.browseTags(user.id)
-  res.status(200).json({ tags })
-  return next()
+  new SuccessResponse({ tags }).send(res)
 }
 
 const postTag = async (req, res, next) => {
@@ -37,20 +35,13 @@ const postTag = async (req, res, next) => {
   req.user = user
 
   const { name } = req.body
-
   if (!name || name.length > 32) {
-    const error = {
-      status: 400,
-      message:
-        'Field `name` is required and cannot be empty and must not exceed 32 characters.',
-    }
-    res.status(error.status).json({ error })
-    return next()
+    throw new BadRequestError(
+      '`name` required and must be between 1 - 32 characters',
+    )
   }
-
   const tag = await TagsRepo.createTag(user.id, name)
-  res.status(201).json({ tag })
-  return next()
+  new CreatedSuccessResponse({ tag }).send(res)
 }
 
 const deleteTag = async (req, res, next) => {
@@ -62,16 +53,9 @@ const deleteTag = async (req, res, next) => {
 
   const deleted = await TagsRepo.removeTag(user.id, id)
   if (!deleted) {
-    const error = {
-      status: 404,
-      message:
-        'Could not find any tag with the given id associated with the authorized user.',
-    }
-    res.status(error.status).json({ error })
-    return next()
+    throw new NotFoundError('No tag found with the given id')
   }
-  res.status(204).end()
-  return next()
+  new EmptySuccessResponse().send(res)
 }
 
 module.exports = {

--- a/src/api/controllers/things.js
+++ b/src/api/controllers/things.js
@@ -1,3 +1,9 @@
+const {
+  SuccessResponse,
+  EmptySuccessResponse,
+  CreatedSuccessResponse,
+} = require('../../core/api-response')
+const { BadRequestError, NotFoundError } = require('../../core/api-error')
 const { ThingsRepo } = require('../../database/repositories')
 
 const getThings = async (req, res, next) => {
@@ -8,7 +14,7 @@ const getThings = async (req, res, next) => {
   // const { include } = req.query
 
   const things = await ThingsRepo.browseThings(user.id)
-  res.status(200).json({ things })
+  new SuccessResponse({ things }).send(res)
 }
 
 const postThing = async (req, res, next) => {
@@ -17,8 +23,7 @@ const postThing = async (req, res, next) => {
   // check thing attributes here
 
   const thing = await ThingsRepo.createThing(user.id, data)
-  res.status(201).json({ thing })
-  return next()
+  new CreatedSuccessResponse({ thing }).send(res)
 }
 
 const patchThing = async (req, res, next) => {
@@ -28,13 +33,7 @@ const patchThing = async (req, res, next) => {
 
   // request body does not meet endpoint constraints
   if (!data || typeof data.surfaced !== 'boolean') {
-    const error = {
-      status: 400,
-      message:
-        'Missing or malformed request body. Field `surfaced` is required!',
-    }
-    res.status(error.status).json({ error })
-    return next()
+    throw new BadRequestError('Missing or malformed request body')
   }
 
   // remove all other attributes other than `surfaced`
@@ -46,16 +45,9 @@ const patchThing = async (req, res, next) => {
 
   const updated = await ThingsRepo.updateThing(user.id, id, data)
   if (!updated) {
-    const error = {
-      status: 404,
-      message:
-        'Could not find any thing with the given id associated with the authorized user.',
-    }
-    res.status(error.status).json({ error })
-    return next()
+    throw new NotFoundError('No thing found with the given id')
   }
-  res.status(204).end()
-  return next()
+  new EmptySuccessResponse().send(res)
 }
 
 const deleteThing = async (req, res, next) => {
@@ -64,16 +56,9 @@ const deleteThing = async (req, res, next) => {
 
   const deleted = await ThingsRepo.removeThing(user.id, id)
   if (!deleted) {
-    const error = {
-      status: 404,
-      message:
-        'Could not find any thing with the given id associated with the authorized user.',
-    }
-    res.status(error.status).json({ error })
-    return next()
+    throw new NotFoundError('No thing found with the given id')
   }
-  res.status(204).end()
-  return next()
+  new EmptySuccessResponse().send(res)
 }
 
 module.exports = { getThings, postThing, patchThing, deleteThing }

--- a/src/api/helpers/async-handler.js
+++ b/src/api/helpers/async-handler.js
@@ -6,7 +6,7 @@
  *    the catch-all error handler.
  */
 const asyncHandler = execution => (req, res, next) => {
-  execution(req, res, next).catch(error => next(error.toString()))
+  execution(req, res, next).catch(next)
 }
 
 module.exports = asyncHandler

--- a/src/core/api-error.js
+++ b/src/core/api-error.js
@@ -1,0 +1,66 @@
+const {
+  InternalErrorResponse,
+  BadRequestResponse,
+  NotFoundResponse,
+} = require('./api-response')
+
+class APIError extends Error {
+  /**
+   * TODO
+   * @param {*} type
+   * @param {*} message
+   */
+  constructor(type, message) {
+    super(message)
+    this.type = type
+  }
+
+  static handle(error, res) {
+    switch (error.type) {
+      case APIError.ERROR_TYPE.BAD_REQUEST:
+        return new BadRequestResponse(error.message).send(res)
+      case APIError.ERROR_TYPE.NOT_FOUND:
+        return new NotFoundResponse(error.message).send(res)
+      case APIError.ERROR_TYPE.INTERNAL:
+      default:
+        let { message } = error
+        if (process.env.NODE_ENV === 'production' || !message) {
+          message = 'An internal server error occurred, please try again later.'
+        }
+        return new InternalErrorResponse(message).send(res)
+    }
+  }
+}
+
+APIError.ERROR_TYPE = {
+  BAD_REQUEST: 'BadRequestError',
+  UNAUTHORIZED: 'UnauthorizedError',
+  NOT_FOUND: 'NotFoundError',
+
+  INTERNAL: 'InternalError',
+}
+
+class BadRequestError extends APIError {
+  constructor(message = 'Bad request—check data fields and try again') {
+    super(APIError.ERROR_TYPE.BAD_REQUEST, message)
+  }
+}
+
+class NotFoundError extends APIError {
+  constructor(message = 'No resource found for the given attribute') {
+    super(APIError.ERROR_TYPE.NOT_FOUND, message)
+  }
+}
+
+class InternalError extends APIError {
+  constructor(message = '') {
+    super(APIError.ERROR_TYPE.INTERNAL, message)
+  }
+}
+
+module.exports = {
+  APIError,
+  InternalError,
+  BadRequestError,
+  NotFoundError,
+}

--- a/src/core/api-response.js
+++ b/src/core/api-response.js
@@ -1,0 +1,88 @@
+class APIResponse {
+  /**
+   * TODO
+   * @param {*} status
+   * @param {*} payload
+   */
+  constructor(status, payload) {
+    this.status = status
+    this.payload = payload
+  }
+
+  prepare(res, response) {
+    return res.status(this.status).json(response)
+  }
+
+  send(res) {
+    return this.prepare(res, this)
+  }
+}
+
+APIResponse.STATUS_CODE = {
+  SUCCESS: 200,
+  CREATED: 201,
+  NO_CONTENT: 204,
+
+  BAD_REQUEST: 400,
+  UNAUTHORIZED: 401,
+  NOT_FOUND: 404,
+
+  INTERNAL_ERROR: 500,
+}
+
+class SuccessResponse extends APIResponse {
+  constructor(data) {
+    super(APIResponse.STATUS_CODE.SUCCESS, data)
+  }
+}
+
+class EmptySuccessResponse extends APIResponse {
+  constructor() {
+    super(APIResponse.STATUS_CODE.NO_CONTENT)
+  }
+}
+
+class CreatedSuccessResponse extends APIResponse {
+  constructor(data) {
+    super(APIResponse.STATUS_CODE.CREATED, data)
+  }
+}
+
+class BaseErrorResponse extends APIResponse {
+  constructor(status, message) {
+    super(status)
+    this.message = message
+  }
+
+  send(res) {
+    return res.status(this.status).json({ error: this })
+  }
+}
+
+class BadRequestResponse extends BaseErrorResponse {
+  constructor(message) {
+    super(APIResponse.STATUS_CODE.BAD_REQUEST, message)
+  }
+}
+
+class NotFoundResponse extends BaseErrorResponse {
+  constructor(message) {
+    super(APIResponse.STATUS_CODE.NOT_FOUND, message)
+  }
+}
+
+class InternalErrorResponse extends BaseErrorResponse {
+  constructor(message) {
+    super(APIResponse.STATUS_CODE.INTERNAL_ERROR, message)
+  }
+}
+
+module.exports = {
+  SuccessResponse,
+  EmptySuccessResponse,
+  CreatedSuccessResponse,
+
+  InternalErrorResponse,
+  BadRequestResponse,
+  NotFoundResponse,
+}

--- a/tests/controllers/tags.test.js
+++ b/tests/controllers/tags.test.js
@@ -9,8 +9,8 @@ describe('Tags Endpoint(s)', () => {
     })
     test('should return a `tag` object', async () => {
       const res = await request(app).get('/v1/tags/2')
-      expect(res.body).toHaveProperty('tag')
-      expect(typeof res.body.tag).toBe('object')
+      expect(res.body.payload).toHaveProperty('tag')
+      expect(typeof res.body.payload.tag).toBe('object')
     })
 
     test('should return HTTP 404 status code if not found', async () => {
@@ -32,8 +32,8 @@ describe('Tags Endpoint(s)', () => {
     })
     test('should return an array of tags', async () => {
       const res = await request(app).get('/v1/tags')
-      expect(res.body).toHaveProperty('tags')
-      expect(Array.isArray(res.body.tags)).toBeTruthy()
+      expect(res.body.payload).toHaveProperty('tags')
+      expect(Array.isArray(res.body.payload.tags)).toBeTruthy()
     })
   })
 })


### PR DESCRIPTION
This commit introduces two new modules: `APIResponse` and `APIError`. These modules are intended to simplify request and error handling, respectively. They also act as means of standardizing the responses returned by the API as well as reducing the amount of code in the controllers.

Resources:
 - https://afteracademy.com/blog/design-node-js-backend-architecture-like-a-pro